### PR TITLE
Rebase er linter update

### DIFF
--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -116,7 +116,7 @@ def metadata_folder_has_one_or_less_file(package: Path) -> bool:
     else:
         return True
 
-def metadata_file_expected_types(package: Path) -> bool:
+def metadata_file_is_expected_types(package: Path) -> bool:
     """The metadata folder can only have FTK report and/or carrier photograph(s)"""
     for metadata_path in package.glob('metadata'):
         md_file_ls = [x for x in metadata_path.iterdir() if x.is_file()]

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -128,48 +128,18 @@ def metadata_file_is_expected_types(package: Path) -> bool:
         else:
             return False
 
-def metadata_file_has_valid_filename(package: Path) -> bool:
-    """FTK metadata CSV name should conform to M###_(ER|DI|EM)_####.(csv|CSV)"""
+def metadata_FTK_file_has_valid_filename(package: Path) -> bool:
+    """FTK metadata name should conform to M###_(ER|DI|EM)_####.[ct]sv"""
     for metadata_path in package.glob('metadata'):
-        md_file_ls = [x for x in metadata_path.iterdir() if x.is_file()]
+        ctsv_file_ls = [x for x in metadata_path.iterdir() if
+                        x.is_file() and x.suffix.lower() in ['.csv', '.tsv']]
 
-    if len(md_file_ls) == 1:
-        for file in md_file_ls:
-            if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.(csv|CSV)', file.name):
+    for ctsv in ctsv_file_ls:
+        if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.[ct]sv', ctsv.name.lower()):
                 return True
-            else:
-                if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.(tsv|TSV)', file.name):
-                    LOGGER.warning(f"{package.name}: The metadata file, {file.name}, is a TSV file.")
-                    return False
-                else:
-                    LOGGER.warning(f"{package.name} has unknown metadata file, {file.name}")
-                    return False
-    elif len(md_file_ls) > 1:
-        good_csv = []
-        good_tsv = []
-        unknown_files = []
-        for file in md_file_ls:
-            if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.(csv|CSV)', file.name):
-                good_csv.append(file)
-            elif re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.(tsv|TSV)', file.name):
-                good_tsv.append(file)
-            else:
-                unknown_files.append(file)
-
-        if good_tsv or unknown_files:
-            if good_tsv:
-                LOGGER.warning(f"{package.name} metadata folder has FTK TSV files")
-            if unknown_files:
-                LOGGER.warning(f"{package.name} metadata folder has non-FTK exported files")
+        else:
+            LOGGER.error(f"{package.name} has nonconforming FTK file, {ctsv.name}.")
             return False
-
-        if any(good_csv):
-            LOGGER.warning(f"{package.name}has more than one FTK-exported CSV files")
-            return False
-
-    else:
-        LOGGER.warning(f"{package.name} has no files in the metadata folder")
-        return False
 
 def objects_folder_has_file(package: Path) -> bool:
     """The objects folder must have one or more files, which can be in folder(s)"""

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -249,8 +249,7 @@ def main():
     print(f'\nTotal packages ran: {counter}')
     if valid:
         print(f'''
-        The following {len(valid)} packages are valid:
-        {", ".join(str(x) for x in valid)}''')
+        The following {len(valid)} packages are valid: {valid}''')
     if invalid:
         print(f'''
         The following {len(invalid)} packages are invalid: {invalid}''')

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -116,6 +116,18 @@ def metadata_folder_has_one_or_less_file(package: Path) -> bool:
     else:
         return True
 
+def metadata_file_expected_types(package: Path) -> bool:
+    """The metadata folder can only have FTK report and/or carrier photograph(s)"""
+    for metadata_path in package.glob('metadata'):
+        md_file_ls = [x for x in metadata_path.iterdir() if x.is_file()]
+
+    expected_types = ['.csv', '.tsv', '.jpg']
+    for file in md_file_ls:
+        if file.suffix.lower() in expected_types:
+            return True
+        else:
+            return False
+
 def metadata_file_has_valid_filename(package: Path) -> bool:
     """FTK metadata CSV name should conform to M###_(ER|DI|EM)_####.(csv|CSV)"""
     for metadata_path in package.glob('metadata'):

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -46,7 +46,7 @@ def package_has_valid_name(package: Path):
     """Top level folder name has to conform to M###_(ER|DI|EM)_####"""
     folder_name = package.name
     match = re.fullmatch(r'M\d+_(ER|DI|EM)_\d+', folder_name)
-    
+
     if match:
         return True
     else:
@@ -99,6 +99,7 @@ def metadata_folder_has_one_or_less_file(package: Path):
         return True
 
 def metadata_file_has_valid_filename(package: Path):
+    "To add image and tsv as valid files in metadata folder"
     """FTK metadata CSV name should conform to M###_(ER|DI|EM)_####.(csv|CSV)"""
     for metadata_path in package.glob('metadata'):
         md_file_ls = [x for x in metadata_path.iterdir() if x.is_file()]
@@ -135,12 +136,12 @@ def metadata_file_has_valid_filename(package: Path):
     else:
         LOGGER.warning("There are no files in the metadata folder")
         return True
-        
+
 def objects_folder_has_file(package: Path):
     """The objects folder must have one or more files, which can be in folder(s)"""
     for objects_path in package.glob('objects'):
         obj_filepaths = [x for x in objects_path.rglob('*') if x.is_file()]
-    
+
     if not any(obj_filepaths):
         LOGGER.error("The objects folder does not have any file")
         return False

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -126,6 +126,7 @@ def metadata_file_is_expected_types(package: Path) -> bool:
         if file.suffix.lower() in expected_types:
             return True
         else:
+            LOGGER.error(f"{package.name} has unexpected file {file.name}")
             return False
 
 def metadata_FTK_file_has_valid_filename(package: Path) -> bool:
@@ -135,8 +136,8 @@ def metadata_FTK_file_has_valid_filename(package: Path) -> bool:
                         x.is_file() and x.suffix.lower() in ['.csv', '.tsv']]
 
     for ctsv in ctsv_file_ls:
-        if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.[ct]sv', ctsv.name.lower()):
-                return True
+        if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+', ctsv.stem):
+            return True
         else:
             LOGGER.error(f"{package.name} has nonconforming FTK file, {ctsv.name}.")
             return False
@@ -185,7 +186,6 @@ def lint_package(package: Path) -> Literal['valid', 'invalid', 'needs review']:
 
     less_strict_tests = [
         metadata_folder_has_one_or_less_file,
-        metadata_file_has_valid_filename,
         package_has_no_hidden_file
     ]
 
@@ -198,6 +198,8 @@ def lint_package(package: Path) -> Literal['valid', 'invalid', 'needs review']:
         package_has_valid_subfolder_names,
         objects_folder_has_no_access_folder,
         metadata_folder_is_flat,
+        metadata_file_is_expected_types,
+        metadata_FTK_file_has_valid_filename,
         objects_folder_has_file,
         package_has_no_bag,
         package_has_no_zero_bytes_file

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -56,6 +56,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         '--log_folder',
+        help='''Optional. Designate where to save the log file,
+        or it will be saved in current directory''',
         default='.'
     )
 

--- a/bin/lint_er.py
+++ b/bin/lint_er.py
@@ -2,8 +2,23 @@ from pathlib import Path
 import argparse
 import re
 import logging
+from typing import Literal
+from datetime import datetime
 
 LOGGER = logging.getLogger(__name__)
+
+def _configure_logging(args):
+    log_fn = datetime.now().strftime('lint_%Y_%m_%d_%H_%M.log')
+    log_fpath = Path(args.log_folder + '/' + log_fn)
+    if not log_fpath.is_file():
+        log_fpath.touch()
+
+    logging.basicConfig(level=logging.WARNING,
+                        format = "%(asctime)s - %(levelname)8s - %(message)s",
+                        datefmt='%Y-%m-%d %H:%M:%S',
+                        filename=log_fpath,
+                        encoding='utf-8'
+                        )
 
 def parse_args() -> argparse.Namespace:
     """Validate and return command-line args"""
@@ -39,10 +54,14 @@ def parse_args() -> argparse.Namespace:
         dest='packages',
         action='extend'
     )
+    parser.add_argument(
+        '--log_folder',
+        default='.'
+    )
 
     return parser.parse_args()
 
-def package_has_valid_name(package: Path):
+def package_has_valid_name(package: Path) -> bool:
     """Top level folder name has to conform to M###_(ER|DI|EM)_####"""
     folder_name = package.name
     match = re.fullmatch(r'M\d+_(ER|DI|EM)_\d+', folder_name)
@@ -53,7 +72,7 @@ def package_has_valid_name(package: Path):
         LOGGER.error(f'{folder_name} does not conform to M###_(ER|DI|EM)_####')
         return False
 
-def package_has_valid_subfolder_names(package: Path):
+def package_has_valid_subfolder_names(package: Path) -> bool:
     """Second level folders must have objects and metadata folder"""
     expected = set(['objects', 'metadata'])
     found = set([x.name for x in package.iterdir()])
@@ -61,58 +80,55 @@ def package_has_valid_subfolder_names(package: Path):
     if expected == found:
         return True
     else:
-        LOGGER.error(f'Subfolders should have objects and metadata, found {found}')
+        LOGGER.error(f'{package.name} subfolders should have objects and metadata, found {found}')
         return False
 
-def objects_folder_has_no_access_folder(package: Path):
+def objects_folder_has_no_access_folder(package: Path) -> bool:
     """An access folder within the objects folder indicates it is an older package,
     and the files within the access folder was created by the Library, and should not be ingested"""
     access_dir = list(package.rglob('access'))
 
     if access_dir:
-        LOGGER.error(f'There is an access folder in this package: {access_dir}')
+        LOGGER.error(f'{package.name} has an access folder in this package: {access_dir}')
         return False
     else:
         return True
 
-def metadata_folder_is_flat(package: Path):
+def metadata_folder_is_flat(package: Path) -> bool:
     """The metadata folder should not have folder structure"""
     for metadata_path in package.glob('metadata'):
         md_dir_ls = [x for x in metadata_path.iterdir() if x.is_dir()]
-    if not md_dir_ls:
+    if md_dir_ls:
+        LOGGER.error(f'{package.name} has unexpected directory: {md_dir_ls}')
+        return False
+    else:
         return True
-    elif len(md_dir_ls) == 1 and md_dir_ls[0].name == 'submissionDocumentation':
-        LOGGER.error(f'The metadata folder has submissionDocumentation folder')
-        return False
-    elif len(md_dir_ls) != 0:
-        LOGGER.error(f'The metadata folder has unexpected directory: {md_dir_ls}')
-        return False
 
-def metadata_folder_has_one_or_less_file(package: Path):
+def metadata_folder_has_one_or_less_file(package: Path) -> bool:
     """The metadata folder should have zero to one file"""
     for metadata_path in package.glob('metadata'):
         md_file_ls = [x for x in metadata_path.iterdir() if x.is_file()]
     if len(md_file_ls) > 1:
-        LOGGER.warning(f'There are more than one file in the metadata folder: {md_file_ls}')
+        LOGGER.warning(f'{package.name} has more than one file in the metadata folder: {md_file_ls}')
         return False
     else:
         return True
 
-def metadata_file_has_valid_filename(package: Path):
-    "To add image and tsv as valid files in metadata folder"
+def metadata_file_has_valid_filename(package: Path) -> bool:
     """FTK metadata CSV name should conform to M###_(ER|DI|EM)_####.(csv|CSV)"""
     for metadata_path in package.glob('metadata'):
         md_file_ls = [x for x in metadata_path.iterdir() if x.is_file()]
+
     if len(md_file_ls) == 1:
         for file in md_file_ls:
             if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.(csv|CSV)', file.name):
                 return True
             else:
                 if re.fullmatch(r'M\d+_(ER|DI|EM)_\d+.(tsv|TSV)', file.name):
-                    LOGGER.warning(f"The metadata file, {file.name}, is a TSV file.")
+                    LOGGER.warning(f"{package.name}: The metadata file, {file.name}, is a TSV file.")
                     return False
                 else:
-                    LOGGER.warning(f"Unknown metadata file, {file.name}")
+                    LOGGER.warning(f"{package.name} has unknown metadata file, {file.name}")
                     return False
     elif len(md_file_ls) > 1:
         good_csv = []
@@ -125,67 +141,121 @@ def metadata_file_has_valid_filename(package: Path):
                 good_tsv.append(file)
             else:
                 unknown_files.append(file)
-        if any(good_tsv):
-            LOGGER.warning("The metadata folder has FTK TSV files")
-        if any(unknown_files):
-            LOGGER.warning("The metadata folder has non-FTK exported files")
-        if any(good_csv):
-            LOGGER.warning("There are more than one FTK-exported CSV files")
-        if any(good_tsv) or any(unknown_files) or any(good_csv):
-            return False
-    else:
-        LOGGER.warning("There are no files in the metadata folder")
-        return True
 
-def objects_folder_has_file(package: Path):
+        if good_tsv or unknown_files:
+            if good_tsv:
+                LOGGER.warning(f"{package.name} metadata folder has FTK TSV files")
+            if unknown_files:
+                LOGGER.warning(f"{package.name} metadata folder has non-FTK exported files")
+            return False
+
+        if any(good_csv):
+            LOGGER.warning(f"{package.name}has more than one FTK-exported CSV files")
+            return False
+
+    else:
+        LOGGER.warning(f"{package.name} has no files in the metadata folder")
+        return False
+
+def objects_folder_has_file(package: Path) -> bool:
     """The objects folder must have one or more files, which can be in folder(s)"""
     for objects_path in package.glob('objects'):
         obj_filepaths = [x for x in objects_path.rglob('*') if x.is_file()]
 
     if not any(obj_filepaths):
-        LOGGER.error("The objects folder does not have any file")
+        LOGGER.error(f"{package.name} objects folder does not have any file")
         return False
     return True
 
-def package_has_no_bag(package: Path):
+def package_has_no_bag(package: Path) -> bool:
     """The whole package should not contain any bag"""
     if list(package.rglob('bagit.txt')):
-        LOGGER.error("The package has bag structure")
+        LOGGER.error(f"{package.name} has bag structure")
         return False
     else:
         return True
 
-def package_has_no_hidden_file(package: Path):
+def package_has_no_hidden_file(package: Path) -> bool:
     """The package should not have any hidden file"""
     hidden_ls = [h for h in package.rglob('*') if h.name.startswith('.') or
                  h.name.startswith('Thumbs')]
     if hidden_ls:
-        LOGGER.warning(f"The package has hidden files {hidden_ls}")
+        LOGGER.warning(f"{package.name} has hidden files {hidden_ls}")
         return False
     else:
         return True
 
-def package_has_no_zero_bytes_file(package: Path):
+def package_has_no_zero_bytes_file(package: Path) -> bool:
     """The package should not have any zero bytes file"""
     all_file = [f for f in package.rglob('*') if f.is_file()]
     zero_bytes_ls = [f for f in all_file if f.stat().st_size == 0]
     if zero_bytes_ls:
-        LOGGER.error(f"The package has zero bytes file {zero_bytes_ls}")
+        LOGGER.error(f"{package.name} has zero bytes file {zero_bytes_ls}")
         return False
     else:
         return True
 
-def lint_package() -> bool:
+def lint_package(package: Path) -> Literal['valid', 'invalid', 'needs review']:
     """Run all linting tests against a package"""
-    return True
+    result = 'valid'
+
+    less_strict_tests = [
+        metadata_folder_has_one_or_less_file,
+        metadata_file_has_valid_filename,
+        package_has_no_hidden_file
+    ]
+
+    for test in less_strict_tests:
+        if not test(package):
+            result = 'needs review'
+
+    strict_tests = [
+        package_has_valid_name,
+        package_has_valid_subfolder_names,
+        objects_folder_has_no_access_folder,
+        metadata_folder_is_flat,
+        objects_folder_has_file,
+        package_has_no_bag,
+        package_has_no_zero_bytes_file
+    ]
+
+    for test in strict_tests:
+        if not test(package):
+            result = 'invalid'
+
+    return result
 
 def main():
     args = parse_args()
+    _configure_logging(args)
 
-    if not lint_package():
-        print('package did not lint')
+    valid = []
+    invalid = []
+    needs_review = []
 
-    return False
+    counter = 0
+
+    for package in args.packages:
+        counter += 1
+        result = lint_package(package)
+        if result == 'valid':
+            valid.append(package.name)
+        elif result == 'invalid':
+            invalid.append(package.name)
+        else:
+            needs_review.append(package.name)
+    print(f'\nTotal packages ran: {counter}')
+    if valid:
+        print(f'''
+        The following {len(valid)} packages are valid:
+        {", ".join(str(x) for x in valid)}''')
+    if invalid:
+        print(f'''
+        The following {len(invalid)} packages are invalid: {invalid}''')
+    if needs_review:
+        print(f'''
+        The following {len(needs_review)} packages need review.
+        They may be passed without change after review: {needs_review}''')
 
 if __name__=='__main__':
     main()

--- a/tests/test_lint_er.py
+++ b/tests/test_lint_er.py
@@ -403,7 +403,7 @@ def test_lint_invalid_package(monkeypatch, good_package, capsys):
     monkeypatch.setattr(
         'sys.argv', [
             '../bin/lint_er.py',
-            '--package', str(good_package)
+            '--package', str(bad_package)
         ]
     )
 
@@ -411,4 +411,4 @@ def test_lint_invalid_package(monkeypatch, good_package, capsys):
 
     stdout = capsys.readouterr().out
 
-    assert f'The following packages are invalid: {str(good_package)}' in stdout
+    assert f'The following packages are invalid: {str(bad_package)}' in stdout

--- a/tests/test_lint_er.py
+++ b/tests/test_lint_er.py
@@ -387,7 +387,7 @@ def test_lint_valid_package(monkeypatch, good_package, capsys):
 
     stdout = capsys.readouterr().out
 
-    assert f'The following packages are valid: {str(good_package)}' in stdout
+    assert f'packages are valid: {[str(good_package.name)]}' in stdout
 
 def test_lint_invalid_package(monkeypatch, good_package, capsys):
     """Run entire script with invalid ER"""
@@ -411,4 +411,4 @@ def test_lint_invalid_package(monkeypatch, good_package, capsys):
 
     stdout = capsys.readouterr().out
 
-    assert f'The following packages are invalid: {str(bad_package)}' in stdout
+    assert f'packages are invalid: {[str(bad_package.name)]}' in stdout

--- a/tests/test_lint_er.py
+++ b/tests/test_lint_er.py
@@ -220,38 +220,27 @@ def test_metadata_folder_has_more_than_one_file(good_package):
 
     assert result == False
 
-def test_metadata_file_valid_name(good_package):
-    """FTK metadata CSV name should conform to M###_(ER|DI|EM)_####.(csv|CSV)"""
-    result = lint_er.metadata_file_has_valid_filename(good_package)
+def test_metadata_file_is_expected_types(good_package):
+    """Test that file(s) in the metadata folder are expected types"""
+    result = lint_er.metadata_file_is_expected_types(good_package)
 
     assert result == True
 
-def test_metadata_file_invalid_name_tsv(good_package):
-    """Test that package fails function and gives out correct warning
-    when the metadata file name does not conform to the naming convention,
-    M###_(ER|DI|EM)_####.(csv|CSV), but M###_(ER|DI|EM)_####.(tsv|TSV)"""
+def test_FTK_metadata_file_valid_name(good_package):
+    """FTK metadata CSV/TSV name should conform to M###_(ER|DI|EM)_####.[ct]sv"""
+    result = lint_er.metadata_FTK_file_has_valid_filename(good_package)
+
+    assert result == True
+
+def test_FTK_metadata_file_invalid_name(good_package):
+    """Test that package fails function when the FTK metadata file name
+    does not conform to the naming convention, M###_(ER|DI|EM)_####.[ct]sv"""
     bad_package = good_package
     for metadata_path in bad_package.glob('metadata'):
         for file in [x for x in metadata_path.iterdir() if x.is_file()]:
-            file.rename(metadata_path / 'M12345_ER_0001.tsv')
+            file.rename(metadata_path / 'M12345-0001.csv')
 
-    result = lint_er.metadata_file_has_valid_filename(bad_package)
-
-    assert result == False
-
-def test_metadata_file_invalid_name_more_files(good_package):
-    """Test that package fails function and gives out correct warning when
-    there are more than one file in the second-level metadata folder"""
-    bad_package = good_package
-    for metadata_path in bad_package.glob('metadata'):
-        new_csv = metadata_path.joinpath('M12345_ER_0003.csv')
-        new_csv.touch()
-        new_tsv = metadata_path.joinpath('M12345_ER_0004.tsv')
-        new_tsv.touch()
-        random_file = metadata_path.joinpath('M1234.txt')
-        random_file.touch()
-
-    result = lint_er.metadata_file_has_valid_filename(bad_package)
+    result = lint_er.metadata_FTK_file_has_valid_filename(bad_package)
 
     assert result == False
 

--- a/tests/test_lint_er.py
+++ b/tests/test_lint_er.py
@@ -226,6 +226,18 @@ def test_metadata_file_is_expected_types(good_package):
 
     assert result == True
 
+def test_metadata_file_is_unexpected_types(good_package):
+    """Test that package fails function if the file in the metadata folder
+    are not expected types"""
+    bad_package = good_package
+    for metadata_path in bad_package.glob('metadata'):
+        for file in [x for x in metadata_path.iterdir() if x.is_file()]:
+            file.rename(metadata_path / 'random.txt')
+
+    result = lint_er.metadata_file_is_expected_types(good_package)
+
+    assert result == False
+
 def test_FTK_metadata_file_valid_name(good_package):
     """FTK metadata CSV/TSV name should conform to M###_(ER|DI|EM)_####.[ct]sv"""
     result = lint_er.metadata_FTK_file_has_valid_filename(good_package)


### PR DESCRIPTION
Update the lint_er.py to accept .jpg as metadata files, and change logic for catching non-conforming FTK metadata filename. Tests are also added and passed. The "metadata_folder_has_one_or_less_file" function can potentially be removed, since we technically accept more than one file now due to .jpg. But it is fine to stay too, because it is a less strict condition.

This branch is rebased from "er_linter_update" because the old one has schema API script commits mixed it. "er_linter_update" can be deleted after this branch is approved.